### PR TITLE
Public inboxes are writable by other instances

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -98,7 +98,7 @@ In order to prevent abuse, ALL IDS except for 0 MUST NOT be accessible without p
 
 ## Federation
 
-Each instance MUST have a public inbox (which can be accessed by other servers) and SHOULD have a private outbox (where requests that will be sent to other instances are stashed).
+Each instance MUST have a public inbox (which can be written to by other instances) and SHOULD have a private outbox (where requests that will be sent to other instances are stashed).
 
 Federation works on the following principle:
 


### PR DESCRIPTION
This may be an unnecessary tightening of the spec. It may be a minor information leak if other instances can _read_ from the public inbox. 

(Note: I am assuming we want to standardize on using the word "Instance" over "server" in the protocol specification except in cases where we literally mean a single virtual or physical server. I am happy to include that separately if you prefer)